### PR TITLE
ANS-19664 - prevent for message duplication on transport exception

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -28,7 +28,7 @@ jobs:
                   php-version: "${{ matrix.php-version }}"
 
             - name: "Cache dependencies installed with composer"
-              uses: "actions/cache@v2"
+              uses: "actions/cache@v4"
               with:
                   path: "~/.composer/cache"
                   key: "php-${{ matrix.php-version }}-composer-locked-${{ hashFiles('composer.lock') }}"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -24,7 +24,7 @@ jobs:
                     php-version: "${{ matrix.php-version }}"
 
             -   name: "Cache dependencies installed with composer"
-                uses: "actions/cache@v2"
+                uses: "actions/cache@v4"
                 with:
                     path: "~/.composer/cache"
                     key: "php-${{ matrix.php-version }}-composer-locked-${{ hashFiles('composer.lock') }}"

--- a/src/Transport/AmqpTransport.php
+++ b/src/Transport/AmqpTransport.php
@@ -8,6 +8,8 @@ use Answear\MessengerHeartbeatBundle\Exception\KeepaliveException;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpTransport as BaseAmqpTransport;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\Connection;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\TransportException;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\Transport\Receiver\KeepaliveReceiverInterface;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
@@ -29,6 +31,17 @@ class AmqpTransport extends BaseAmqpTransport implements KeepaliveReceiverInterf
 
             $this->getMessageCount();
         } catch (\Throwable $throwable) {
+            $transportException = $this->getTransportException($throwable);
+            if (null !== $transportException) {
+                /*
+                 * TransportException like AMQPQueueException("Server channel error: 406, message: PRECONDITION_FAILED - delivery acknowledgement on channel 1 timed out."),
+                 * connection lost,
+                 * message will be set as redelivered,
+                 * need to stop worker and don't requeue current message to prevent message duplication
+                 */
+                throw new UnrecoverableMessageHandlingException($transportException->getMessage(), $transportException->getCode(), $transportException);
+            }
+
             throw KeepaliveException::createException($throwable);
         }
     }
@@ -47,5 +60,14 @@ class AmqpTransport extends BaseAmqpTransport implements KeepaliveReceiverInterf
         } catch (\Throwable $throwable) {
             throw new \AMQPConnectionException('Connection without queue.', $throwable->getCode(), $throwable);
         }
+    }
+
+    private function getTransportException(?\Throwable $throwable): ?TransportException
+    {
+        if (null === $throwable || $throwable instanceof TransportException) {
+            return $throwable;
+        }
+
+        return $this->getTransportException($throwable->getPrevious());
     }
 }


### PR DESCRIPTION
We have duplicate messages when AMQPQueueException like `Server channel error: 406, message: PRECONDITION_FAILED - delivery acknowledgement on channel 1 timed out. Timeout value used: 1800000 ms. This timeout value can be configured, see consumers doc guide to learn more` throw.

see https://github.com/answear/messenger-heartbeat-bundle/pull/9/files#r1891809244

I am partially restoring support for this. Thanks @mglowala 